### PR TITLE
Always send Content-Length, even if body is None

### DIFF
--- a/src/dialog/dialog.rs
+++ b/src/dialog/dialog.rs
@@ -361,9 +361,11 @@ impl DialogInner {
         }
         headers.push(Header::MaxForwards(70.into()));
 
-        body.as_ref().map(|b| {
-            headers.push(Header::ContentLength((b.len() as u32).into()));
-        });
+        headers.push(Header::ContentLength(
+            body.as_ref()
+                .map_or(0u32, |b| b.len() as u32)
+                .into(),
+        ));
 
         let req = rsip::Request {
             method,

--- a/src/dialog/dialog.rs
+++ b/src/dialog/dialog.rs
@@ -454,9 +454,11 @@ impl DialogInner {
             .as_ref()
             .map(|c| resp_headers.push(Contact::from(c.clone()).into()));
 
-        body.as_ref().map(|b| {
-            resp_headers.push(Header::ContentLength((b.len() as u32).into()));
-        });
+        resp_headers.push(Header::ContentLength(
+            body.as_ref()
+                .map_or(0u32, |b| b.len() as u32)
+                .into(),
+        ));
 
         resp_headers.push(Header::UserAgent(
             self.endpoint_inner.user_agent.clone().into(),

--- a/src/dialog/dialog.rs
+++ b/src/dialog/dialog.rs
@@ -362,9 +362,7 @@ impl DialogInner {
         headers.push(Header::MaxForwards(70.into()));
 
         headers.push(Header::ContentLength(
-            body.as_ref()
-                .map_or(0u32, |b| b.len() as u32)
-                .into(),
+            body.as_ref().map_or(0u32, |b| b.len() as u32).into(),
         ));
 
         let req = rsip::Request {
@@ -457,9 +455,7 @@ impl DialogInner {
             .map(|c| resp_headers.push(Contact::from(c.clone()).into()));
 
         resp_headers.push(Header::ContentLength(
-            body.as_ref()
-                .map_or(0u32, |b| b.len() as u32)
-                .into(),
+            body.as_ref().map_or(0u32, |b| b.len() as u32).into(),
         ));
 
         resp_headers.push(Header::UserAgent(

--- a/src/transaction/message.rs
+++ b/src/transaction/message.rs
@@ -226,10 +226,14 @@ impl EndpointInner {
                     | Header::CallId(_)
                     | Header::From(_)
                     | Header::To(_)
-                    | Header::MaxForwards(_)
                     | Header::CSeq(_)
             )
         });
+        headers.push(Header::ContentLength(
+            body.as_ref()
+                .map_or(0u32, |b| b.len() as u32)
+                .into(),
+        ));        
         headers.unique_push(Header::UserAgent(self.user_agent.clone().into()));
         Response {
             status_code,

--- a/src/transaction/message.rs
+++ b/src/transaction/message.rs
@@ -230,10 +230,8 @@ impl EndpointInner {
             )
         });
         headers.push(Header::ContentLength(
-            body.as_ref()
-                .map_or(0u32, |b| b.len() as u32)
-                .into(),
-        ));        
+            body.as_ref().map_or(0u32, |b| b.len() as u32).into(),
+        ));
         headers.unique_push(Header::UserAgent(self.user_agent.clone().into()));
         Response {
             status_code,

--- a/src/transport/tests/test_stream_encoding.rs
+++ b/src/transport/tests/test_stream_encoding.rs
@@ -319,7 +319,7 @@ fn test_sip_codec_multiple_messages_with_bodies() {
             assert_eq!(req.call_id_header().unwrap().value(), "test-call-id-2");
         }
         _ => panic!("Expected request message"),
-    } 
+    }
 
     // Buffer should be empty after consuming both messages
     assert_eq!(


### PR DESCRIPTION
This could be the case if you're sending dialog.ringing(Some(headers, None))