### PR TITLE
feature: call_id customization

### DIFF
--- a/src/dialog/invitation.rs
+++ b/src/dialog/invitation.rs
@@ -133,6 +133,7 @@ pub struct InviteOption {
     pub credential: Option<Credential>,
     pub headers: Option<Vec<rsip::Header>>,
     pub support_prack: bool,
+    pub call_id: Option<String>,
 }
 
 pub struct DialogGuard {
@@ -249,10 +250,21 @@ impl DialogLayer {
         }
         .with_tag(make_tag());
 
+        let call_id = opt
+            .call_id
+            .as_ref()
+            .map(|id| rsip::headers::CallId::from(id.clone()));
+
         let via = self.endpoint.get_via(None, None)?;
-        let mut request =
-            self.endpoint
-                .make_request(rsip::Method::Invite, recipient, via, from, to, last_seq);
+        let mut request = self.endpoint.make_request(
+            rsip::Method::Invite,
+            recipient,
+            via,
+            from,
+            to,
+            last_seq,
+            call_id,
+        );
 
         let contact = rsip::typed::Contact {
             display_name: None,

--- a/src/dialog/registration.rs
+++ b/src/dialog/registration.rs
@@ -402,6 +402,7 @@ impl Registration {
             from,
             to,
             self.last_seq,
+            None,
         );
 
         // Thanks to https://github.com/restsend/rsipstack/issues/32

--- a/src/transaction/message.rs
+++ b/src/transaction/message.rs
@@ -62,7 +62,8 @@ impl EndpointInner {
     ///     via,
     ///     from,
     ///     to,
-    ///     1
+    ///     1,
+    ///     None,
     /// );
     /// # Ok(())
     /// # }
@@ -96,10 +97,12 @@ impl EndpointInner {
         from: rsip::typed::From,
         to: rsip::typed::To,
         seq: u32,
+        call_id: Option<rsip::headers::CallId>,
     ) -> rsip::Request {
+        let call_id = call_id.unwrap_or_else(|| make_call_id(self.option.callid_suffix.as_deref()));
         let headers = vec![
             Header::Via(via.into()),
-            Header::CallId(make_call_id(self.option.callid_suffix.as_deref())),
+            Header::CallId(call_id),
             Header::From(from.into()),
             Header::To(to.into()),
             Header::CSeq(rsip::typed::CSeq { seq, method }.into()),


### PR DESCRIPTION
Allow custom `call_id` in invitations

Introduce an optional `call_id` in `InviteOption`. If specified, it will used as `call_id` instead of auto generated one.

Suggestion from #51 .