### PR TITLE
fix hangup for wait ack

### DIFF
--- a/src/dialog/dialog.rs
+++ b/src/dialog/dialog.rs
@@ -226,6 +226,9 @@ impl DialogState {
     pub fn is_terminated(&self) -> bool {
         matches!(self, DialogState::Terminated(_, _))
     }
+    pub fn waiting_ack(&self) -> bool {
+        matches!(self, DialogState::WaitAck(_, _))
+    }
 }
 
 impl DialogInner {
@@ -296,6 +299,9 @@ impl DialogInner {
     }
     pub fn is_terminated(&self) -> bool {
         self.state.lock().unwrap().is_terminated()
+    }
+    pub fn waiting_ack(&self) -> bool {
+        self.state.lock().unwrap().waiting_ack()
     }
     pub fn get_local_seq(&self) -> u32 {
         self.local_seq.load(Ordering::Relaxed)

--- a/src/dialog/server_dialog.rs
+++ b/src/dialog/server_dialog.rs
@@ -350,7 +350,7 @@ impl ServerInviteDialog {
     /// # }
     /// ```
     pub async fn bye(&self) -> Result<()> {
-        if !self.inner.is_confirmed() {
+        if !self.inner.is_confirmed() && !self.inner.waiting_ack() {
             return Ok(());
         }
         info!(id=%self.id(), "sending bye request");


### PR DESCRIPTION
For UAS that sent 200 but have not received ACK, it can not CANCEL and also can not BYE.
```rust
    pub fn can_cancel(&self) -> bool {
        matches!(
            self,
            DialogState::Calling(_) | DialogState::Trying(_) | DialogState::Early(_, _)
        )
    }
    pub fn is_confirmed(&self) -> bool {
        matches!(self, DialogState::Confirmed(_, _))
    }
 ```