### PR TITLE
fix(sip): ack for sip over websocket

### DIFF
--- a/src/transaction/transaction.rs
+++ b/src/transaction/transaction.rs
@@ -471,14 +471,20 @@ impl Transaction {
                 if resp.status_code.kind() == StatusCodeKind::Successful {
                     // 2xx response, set destination from request
                     if let Some(dest) = destination_from_request(req) {
-                        let (conn, addr) = self
+                        match self
                             .endpoint_inner
                             .transport_layer
                             .lookup(&dest, Some(&self.key))
-                            .await?;
-
-                        connection = Some(conn);
-                        self.destination = Some(addr);
+                            .await
+                        {
+                            Ok((conn, addr)) => {
+                                connection = Some(conn);
+                                self.destination = Some(addr);
+                            }
+                            Err(e) => {
+                                tracing::warn!("failed to lookup destination: {}", e);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
for sip over websocket, like sipjs, which its contact is an unreachable addresss `Contact: <sip:jb7crfn2@akdbpgtm0meh.invalid;transport=ws>`
Since it cannot contact directly,
This will lead the sip client not ACKed.