### PR TITLE
fix #53

### DIFF
--- a/src/dialog/client_dialog.rs
+++ b/src/dialog/client_dialog.rs
@@ -196,11 +196,6 @@ impl ClientInviteDialog {
         cancel_request
             .headers_mut()
             .retain(|h| !matches!(h, Header::ContentLength(_) | Header::ContentType(_)));
-
-        cancel_request
-            .to_header_mut()?
-            .mut_tag(self.id().to_tag.clone().into())?; // ensure to-tag has tag param
-
         cancel_request.method = rsip::Method::Cancel;
         let invite_seq = self.inner.initial_request.cseq_header()?.seq()?;
         cancel_request


### PR DESCRIPTION
* Removing to tag for CANCEL, according [RFC 3261 9.1 Client Behavior](https://datatracker.ietf.org/doc/html/rfc3261#section-9.1) 
>  The Request-URI, Call-ID, **To**, the numeric part of CSeq, and From header
   fields in the CANCEL request MUST be identical to those in the
   request being cancelled, **including tags**.  

That means, the CANCEL should not have TO tag.

* add api `get_client_dialog_by_call_id`
