### PR TITLE
feat: add lookup of client INVITE dialogs by Call-ID

### DIFF
--- a/src/dialog/dialog_layer.rs
+++ b/src/dialog/dialog_layer.rs
@@ -1,6 +1,7 @@
 use super::authenticate::Credential;
 use super::dialog::DialogStateSender;
 use super::{dialog::Dialog, server_dialog::ServerInviteDialog, DialogId};
+use crate::dialog::client_dialog::ClientInviteDialog;
 use crate::dialog::dialog::{DialogInner, DialogStateReceiver};
 use crate::transaction::key::TransactionRole;
 use crate::transaction::make_tag;
@@ -237,6 +238,33 @@ impl DialogLayer {
             },
             Err(_) => None,
         }
+    }
+    /// Returns all client-side INVITE dialogs (UAC) that share the given Call-ID.
+    ///
+    /// In a forking scenario, multiple client dialogs can exist for the same
+    /// Call-ID (same local From-tag, different remote To-tags). This helper
+    /// scans the internal dialog registry and returns all `ClientInviteDialog`
+    /// instances whose `DialogId.call_id` equals the provided `call_id`.
+    ///
+    /// The returned vector may be empty if no matching client dialogs are found.
+    pub fn get_client_dialog_by_call_id(&self, call_id: &str) -> Vec<ClientInviteDialog> {
+        let dialogs = match self.inner.dialogs.read() {
+            Ok(guard) => guard,
+            Err(_) => {
+                // If the lock is poisoned, we conservatively return an empty list.
+                return Vec::new();
+            }
+        };
+
+        dialogs
+            .values()
+            .filter_map(|dlg| match dlg {
+                Dialog::ClientInvite(client_dlg) if client_dlg.id().call_id == call_id => {
+                    Some(client_dlg.clone())
+                }
+                _ => None,
+            })
+            .collect()
     }
 
     pub fn remove_dialog(&self, id: &DialogId) {


### PR DESCRIPTION
This PR adds lookup of client INVITE dialogs by Call-ID.

It allows retrieving an existing client dialog using the Call-ID.