### PR TITLE
fix(cancel): destination in invite option is not used by CANCEL

### DIFF
--- a/src/dialog/dialog.rs
+++ b/src/dialog/dialog.rs
@@ -700,6 +700,15 @@ impl DialogInner {
         let key = TransactionKey::from_request(&request, TransactionRole::Client)?;
         let mut tx = Transaction::new_client(key, request, self.endpoint_inner.clone(), None);
 
+        if matches!(method, Method::Cancel) {
+            self.remote_uri
+                .lock()
+                .map(|guard| {
+                    tx.destination = SipAddr::try_from(guard.clone()).ok();
+                })
+                .ok();
+        }
+
         if let Some(route) = tx.original.route_header() {
             if let Some(first_route) = route.typed().ok().and_then(|r| r.uris().first().cloned()) {
                 tx.destination = SipAddr::try_from(&first_route.uri).ok();

--- a/src/dialog/invitation.rs
+++ b/src/dialog/invitation.rs
@@ -506,6 +506,16 @@ impl DialogLayer {
             tx.tu_sender.clone(),
         )?;
 
+        if let Some(destination) = &tx.destination {
+            let uri = destination.clone().into();
+            dlg_inner
+                .remote_uri
+                .lock()
+                .map(|mut guard| {
+                    *guard = uri;
+                })
+                .ok();
+        }
         let dialog = ClientInviteDialog {
             inner: Arc::new(dlg_inner),
         };


### PR DESCRIPTION
If destination of InviteOption is set, the destination will not be used for CANCEL.

fix:
* save destination of invite to remote_uri of dialog.
* set remote_uri to destination of CANCEL transaction.