### PR TITLE
cancel wait for 487 to invite

### DIFF
--- a/src/dialog/authenticate.rs
+++ b/src/dialog/authenticate.rs
@@ -124,7 +124,7 @@ pub struct Credential {
 /// // This is typically called automatically by dialog methods
 /// let new_tx = handle_client_authenticate(
 ///     new_seq,
-///     original_tx,
+///     &original_tx,
 ///     auth_challenge_response,
 ///     &credential
 /// ).await?;
@@ -159,7 +159,7 @@ pub struct Credential {
 ///                 StatusCode::Unauthorized | StatusCode::ProxyAuthenticationRequired => {
 ///                     // Handle authentication challenge
 ///                     let auth_tx = handle_client_authenticate(
-///                         new_seq, tx, resp, &credential
+///                         new_seq, &tx, resp, &credential
 ///                     ).await?;
 ///
 ///                     // Send authenticated request
@@ -186,7 +186,7 @@ pub struct Credential {
 /// This function handles SIP authentication challenges and creates authenticated requests.
 pub async fn handle_client_authenticate(
     new_seq: u32,
-    tx: Transaction,
+    tx: &Transaction,
     resp: Response,
     cred: &Credential,
 ) -> Result<Transaction> {

--- a/src/dialog/client_dialog.rs
+++ b/src/dialog/client_dialog.rs
@@ -623,7 +623,7 @@ impl ClientInviteDialog {
 
     pub async fn process_invite(
         &self,
-        mut tx: Transaction,
+        tx: &mut Transaction,
     ) -> Result<(DialogId, Option<Response>)> {
         self.inner.transition(DialogState::Calling(self.id()))?;
         let mut auth_sent = false;
@@ -662,7 +662,7 @@ impl ClientInviteDialog {
                         }
                         auth_sent = true;
                         if let Some(credential) = &self.inner.credential {
-                            tx = handle_client_authenticate(
+                            *tx = handle_client_authenticate(
                                 self.inner.increment_local_seq(),
                                 tx,
                                 resp,

--- a/src/dialog/dialog.rs
+++ b/src/dialog/dialog.rs
@@ -596,7 +596,7 @@ impl DialogInner {
                         auth_sent = true;
                         if let Some(cred) = &self.credential {
                             let new_seq = self.increment_local_seq();
-                            tx = handle_client_authenticate(new_seq, tx, resp, cred).await?;
+                            tx = handle_client_authenticate(new_seq, &tx, resp, cred).await?;
                             tx.send().await?;
                             continue;
                         } else {
@@ -921,7 +921,7 @@ impl DialogInner {
                                 rsip::Method::Cancel => self.get_local_seq(),
                                 _ => self.increment_local_seq(),
                             };
-                            tx = handle_client_authenticate(new_seq, tx, resp, cred).await?;
+                            tx = handle_client_authenticate(new_seq, &tx, resp, cred).await?;
                             tx.send().await?;
                             continue;
                         } else {

--- a/src/dialog/registration.rs
+++ b/src/dialog/registration.rs
@@ -448,7 +448,7 @@ impl Registration {
 
                             // Handle authentication with the existing transaction
                             // The contact will be updated in the next registration cycle if needed
-                            tx = handle_client_authenticate(self.last_seq, tx, resp, cred).await?;
+                            tx = handle_client_authenticate(self.last_seq, &tx, resp, cred).await?;
 
                             tx.send().await?;
                             auth_sent = true;

--- a/src/dialog/tests/test_authenticate.rs
+++ b/src/dialog/tests/test_authenticate.rs
@@ -106,7 +106,7 @@ async fn test_authenticate_via_header_branch_update() -> crate::Result<()> {
     };
 
     // Call handle_client_authenticate
-    let new_tx = handle_client_authenticate(2, tx, resp, &cred).await?;
+    let new_tx = handle_client_authenticate(2, &tx, resp, &cred).await?;
 
     // Verify the new request has updated Via header
     let new_via = new_tx


### PR DESCRIPTION
Current implementation,  cancel does not wait the invite 487, the ACK is with the ACK placeholder, So the DialogState:Terminate will not be received by the state receiver.