### PR TITLE
Fix collapsing of multiple Header::Other in responses

### DIFF
--- a/src/dialog/dialog.rs
+++ b/src/dialog/dialog.rs
@@ -873,7 +873,19 @@ impl DialogInner {
 
         if let Some(headers) = headers {
             for header in headers {
-                resp_headers.unique_push(header);
+                match &header {
+                    rsip::Header::Other(name, _) => {
+                        let lname = name.to_ascii_lowercase();
+                        resp_headers.retain(|h| {
+                            !matches!(
+                                h,
+                                rsip::Header::Other(n, _) if n.to_ascii_lowercase() == lname
+                            )
+                        });
+                        resp_headers.push(header);
+                    }
+                    _ => resp_headers.unique_push(header),
+                }
             }
         }
 


### PR DESCRIPTION
Problem

DialogInner::make_response() uses unique_push() for all headers, which causes all Header::Other(...) headers to be treated as a single entry.

As a result, multiple custom headers (e.g. X-*) are collapsed into one and lost in SIP responses.