### PR TITLE
Refactor dialog transition return type

### DIFF
--- a/examples/client/main.rs
+++ b/examples/client/main.rs
@@ -523,9 +523,7 @@ async fn process_invite(opt: &MediaSessionOption, dialog: ServerInviteDialog) ->
     if opt.random_reject > 0 {
         if rand::random::<u32>() % opt.random_reject == 0 {
             info!("Randomly rejecting the call");
-            dialog
-                .reject(Some(rsip::StatusCode::BusyHere), Some("Busy here".into()))
-                .ok();
+            dialog.reject(Some(rsip::StatusCode::BusyHere), Some("Busy here".into()));
             return Ok(());
         }
     }
@@ -597,7 +595,7 @@ async fn process_invite(opt: &MediaSessionOption, dialog: ServerInviteDialog) ->
                                 info!("User answered the call");
                             } else if r == "r" {
                                 info!("User rejected the call");
-                                dialog.reject(Some(rsip::StatusCode::BusyHere), Some("Busy here".into())).ok();
+                                dialog.reject(Some(rsip::StatusCode::BusyHere), Some("Busy here".into()));
                                 rejected = true;
                                 return;
                             } else {

--- a/src/dialog/client_dialog.rs
+++ b/src/dialog/client_dialog.rs
@@ -170,7 +170,7 @@ impl ClientInviteDialog {
         }
 
         self.inner
-            .transition(DialogState::Terminated(self.id(), TerminatedReason::UacBye))?;
+            .transition(DialogState::Terminated(self.id(), TerminatedReason::UacBye));
         Ok(())
     }
 
@@ -329,7 +329,7 @@ impl ClientInviteDialog {
                 if resp.status_code == StatusCode::OK {
                     let (handle, _) = TransactionHandle::new();
                     self.inner
-                        .transition(DialogState::Updated(self.id(), request, handle))?;
+                        .transition(DialogState::Updated(self.id(), request, handle));
                 }
             }
             _ => {}
@@ -620,7 +620,7 @@ impl ClientInviteDialog {
     async fn handle_bye(&mut self, tx: &mut Transaction) -> Result<()> {
         debug!(id = %self.id(), uri = %tx.original.uri, "received bye");
         self.inner
-            .transition(DialogState::Terminated(self.id(), TerminatedReason::UasBye))?;
+            .transition(DialogState::Terminated(self.id(), TerminatedReason::UasBye));
         tx.reply(rsip::StatusCode::OK).await?;
         Ok(())
     }
@@ -629,7 +629,7 @@ impl ClientInviteDialog {
         debug!(id = %self.id(), uri = %tx.original.uri, "received info");
         let (handle, rx) = TransactionHandle::new();
         self.inner
-            .transition(DialogState::Info(self.id(), tx.original.clone(), handle))?;
+            .transition(DialogState::Info(self.id(), tx.original.clone(), handle));
         self.inner.process_transaction_handle(tx, rx).await
     }
 
@@ -637,7 +637,7 @@ impl ClientInviteDialog {
         debug!(id = %self.id(), uri = %tx.original.uri, "received options");
         let (handle, rx) = TransactionHandle::new();
         self.inner
-            .transition(DialogState::Options(self.id(), tx.original.clone(), handle))?;
+            .transition(DialogState::Options(self.id(), tx.original.clone(), handle));
         self.inner.process_transaction_handle(tx, rx).await
     }
 
@@ -645,7 +645,7 @@ impl ClientInviteDialog {
         debug!(id = %self.id(), uri = %tx.original.uri, "received update");
         let (handle, rx) = TransactionHandle::new();
         self.inner
-            .transition(DialogState::Updated(self.id(), tx.original.clone(), handle))?;
+            .transition(DialogState::Updated(self.id(), tx.original.clone(), handle));
         self.inner.process_transaction_handle(tx, rx).await
     }
 
@@ -653,7 +653,7 @@ impl ClientInviteDialog {
         debug!(id = %self.id(), uri = %tx.original.uri, "received reinvite");
         let (handle, rx) = TransactionHandle::new();
         self.inner
-            .transition(DialogState::Updated(self.id(), tx.original.clone(), handle))?;
+            .transition(DialogState::Updated(self.id(), tx.original.clone(), handle));
 
         self.inner.process_transaction_handle(tx, rx).await?;
 
@@ -674,7 +674,7 @@ impl ClientInviteDialog {
         debug!(id = %self.id(), uri = %tx.original.uri, "received refer");
         let (handle, rx) = TransactionHandle::new();
         self.inner
-            .transition(DialogState::Refer(self.id(), tx.original.clone(), handle))?;
+            .transition(DialogState::Refer(self.id(), tx.original.clone(), handle));
 
         self.inner.process_transaction_handle(tx, rx).await
     }
@@ -683,7 +683,7 @@ impl ClientInviteDialog {
         debug!(id = %self.id(), uri = %tx.original.uri, "received message");
         let (handle, rx) = TransactionHandle::new();
         self.inner
-            .transition(DialogState::Message(self.id(), tx.original.clone(), handle))?;
+            .transition(DialogState::Message(self.id(), tx.original.clone(), handle));
 
         self.inner.process_transaction_handle(tx, rx).await
     }
@@ -692,7 +692,7 @@ impl ClientInviteDialog {
         debug!(id = %self.id(), uri = %tx.original.uri, "received notify");
         let (handle, rx) = TransactionHandle::new();
         self.inner
-            .transition(DialogState::Notify(self.id(), tx.original.clone(), handle))?;
+            .transition(DialogState::Notify(self.id(), tx.original.clone(), handle));
         self.inner.process_transaction_handle(tx, rx).await
     }
 
@@ -700,7 +700,7 @@ impl ClientInviteDialog {
         &self,
         tx: &mut Transaction,
     ) -> Result<(DialogId, Option<Response>)> {
-        self.inner.transition(DialogState::Calling(self.id()))?;
+        self.inner.transition(DialogState::Calling(self.id()));
         let mut auth_sent = false;
         tx.send().await?;
         let mut dialog_id = self.id();
@@ -712,13 +712,13 @@ impl ClientInviteDialog {
                     let status = resp.status_code.clone();
 
                     if status == StatusCode::Trying {
-                        self.inner.transition(DialogState::Trying(self.id()))?;
+                        self.inner.transition(DialogState::Trying(self.id()));
                         continue;
                     }
 
                     if matches!(status.kind(), rsip::StatusCodeKind::Provisional) {
                         self.inner.handle_provisional_response(&resp).await?;
-                        self.inner.transition(DialogState::Early(self.id(), resp))?;
+                        self.inner.transition(DialogState::Early(self.id(), resp));
                         continue;
                     }
 
@@ -732,7 +732,7 @@ impl ClientInviteDialog {
                             self.inner.transition(DialogState::Terminated(
                                 self.id(),
                                 TerminatedReason::ProxyAuthRequired,
-                            ))?;
+                            ));
                             break;
                         }
                         auth_sent = true;
@@ -761,7 +761,7 @@ impl ClientInviteDialog {
                             self.inner.transition(DialogState::Terminated(
                                 self.id(),
                                 TerminatedReason::ProxyAuthRequired,
-                            ))?;
+                            ));
                             continue;
                         }
                     }
@@ -797,13 +797,13 @@ impl ClientInviteDialog {
                             *self.inner.remote_uri.lock().unwrap() =
                                 resp.remote_uri(tx.destination.as_ref())?;
                             self.inner
-                                .transition(DialogState::Confirmed(dialog_id.clone(), resp))?;
+                                .transition(DialogState::Confirmed(dialog_id.clone(), resp));
                         }
                         _ => {
                             self.inner.transition(DialogState::Terminated(
                                 self.id(),
                                 TerminatedReason::UasOther(resp.status_code.clone()),
-                            ))?;
+                            ));
                         }
                     }
                     break;

--- a/src/dialog/publication.rs
+++ b/src/dialog/publication.rs
@@ -71,7 +71,7 @@ impl ClientPublicationDialog {
         }
         self.request(Method::Publish, Some(headers), None).await?;
         self.inner
-            .transition(DialogState::Terminated(self.id(), TerminatedReason::UacBye))?;
+            .transition(DialogState::Terminated(self.id(), TerminatedReason::UacBye));
         Ok(())
     }
 
@@ -116,11 +116,8 @@ impl ClientPublicationDialog {
         match tx.original.method {
             Method::Publish => {
                 let (handle, rx) = TransactionHandle::new();
-                self.inner.transition(DialogState::Publish(
-                    self.id(),
-                    tx.original.clone(),
-                    handle,
-                ))?;
+                self.inner
+                    .transition(DialogState::Publish(self.id(), tx.original.clone(), handle));
                 self.inner.process_transaction_handle(tx, rx).await
             }
             _ => Ok(()),
@@ -181,14 +178,13 @@ impl ServerPublicationDialog {
             .tu_sender
             .send(TransactionEvent::Respond(resp.clone()))?;
         self.inner
-            .transition(DialogState::Confirmed(self.id(), resp))?;
+            .transition(DialogState::Confirmed(self.id(), resp));
         Ok(())
     }
 
-    pub async fn close(&self) -> Result<()> {
+    pub async fn close(&self) {
         self.inner
-            .transition(DialogState::Terminated(self.id(), TerminatedReason::UasBye))?;
-        Ok(())
+            .transition(DialogState::Terminated(self.id(), TerminatedReason::UasBye));
     }
 
     pub async fn request(
@@ -235,11 +231,8 @@ impl ServerPublicationDialog {
         match tx.original.method {
             Method::Publish => {
                 let (handle, rx) = TransactionHandle::new();
-                self.inner.transition(DialogState::Publish(
-                    self.id(),
-                    tx.original.clone(),
-                    handle,
-                ))?;
+                self.inner
+                    .transition(DialogState::Publish(self.id(), tx.original.clone(), handle));
                 self.inner.process_transaction_handle(tx, rx).await
             }
             _ => Ok(()),

--- a/src/dialog/subscription.rs
+++ b/src/dialog/subscription.rs
@@ -35,7 +35,7 @@ impl ClientSubscriptionDialog {
         let headers = vec![Header::Expires(0.into())];
         self.request(Method::Subscribe, Some(headers), None).await?;
         self.inner
-            .transition(DialogState::Terminated(self.id(), TerminatedReason::UacBye))?;
+            .transition(DialogState::Terminated(self.id(), TerminatedReason::UacBye));
         Ok(())
     }
 
@@ -77,30 +77,21 @@ impl ClientSubscriptionDialog {
         match tx.original.method {
             Method::Notify => {
                 let (handle, rx) = TransactionHandle::new();
-                self.inner.transition(DialogState::Notify(
-                    self.id(),
-                    tx.original.clone(),
-                    handle,
-                ))?;
+                self.inner
+                    .transition(DialogState::Notify(self.id(), tx.original.clone(), handle));
                 self.inner.process_transaction_handle(tx, rx).await
             }
             Method::Refer => {
                 let (handle, rx) = TransactionHandle::new();
-                self.inner.transition(DialogState::Refer(
-                    self.id(),
-                    tx.original.clone(),
-                    handle,
-                ))?;
+                self.inner
+                    .transition(DialogState::Refer(self.id(), tx.original.clone(), handle));
 
                 self.inner.process_transaction_handle(tx, rx).await
             }
             Method::Message => {
                 let (handle, rx) = TransactionHandle::new();
-                self.inner.transition(DialogState::Message(
-                    self.id(),
-                    tx.original.clone(),
-                    handle,
-                ))?;
+                self.inner
+                    .transition(DialogState::Message(self.id(), tx.original.clone(), handle));
 
                 self.inner.process_transaction_handle(tx, rx).await
             }
@@ -139,7 +130,7 @@ impl ServerSubscriptionDialog {
             .tu_sender
             .send(TransactionEvent::Respond(resp.clone()))?;
         self.inner
-            .transition(DialogState::Confirmed(self.id(), resp))?;
+            .transition(DialogState::Confirmed(self.id(), resp));
         Ok(())
     }
 
@@ -157,10 +148,9 @@ impl ServerSubscriptionDialog {
         self.inner.do_request(request).await
     }
 
-    pub async fn unsubscribe(&self) -> Result<()> {
+    pub async fn unsubscribe(&self) {
         self.inner
-            .transition(DialogState::Terminated(self.id(), TerminatedReason::UasBye))?;
-        Ok(())
+            .transition(DialogState::Terminated(self.id(), TerminatedReason::UasBye));
     }
 
     pub async fn request(
@@ -204,29 +194,20 @@ impl ServerSubscriptionDialog {
         match tx.original.method {
             Method::Subscribe => {
                 let (handle, rx) = TransactionHandle::new();
-                self.inner.transition(DialogState::Updated(
-                    self.id(),
-                    tx.original.clone(),
-                    handle,
-                ))?;
+                self.inner
+                    .transition(DialogState::Updated(self.id(), tx.original.clone(), handle));
                 self.inner.process_transaction_handle(tx, rx).await
             }
             Method::Refer => {
                 let (handle, rx) = TransactionHandle::new();
-                self.inner.transition(DialogState::Refer(
-                    self.id(),
-                    tx.original.clone(),
-                    handle,
-                ))?;
+                self.inner
+                    .transition(DialogState::Refer(self.id(), tx.original.clone(), handle));
                 self.inner.process_transaction_handle(tx, rx).await
             }
             Method::Message => {
                 let (handle, rx) = TransactionHandle::new();
-                self.inner.transition(DialogState::Message(
-                    self.id(),
-                    tx.original.clone(),
-                    handle,
-                ))?;
+                self.inner
+                    .transition(DialogState::Message(self.id(), tx.original.clone(), handle));
                 self.inner.process_transaction_handle(tx, rx).await
             }
             _ => Ok(()),

--- a/src/dialog/tests/test_client_dialog.rs
+++ b/src/dialog/tests/test_client_dialog.rs
@@ -161,7 +161,7 @@ async fn test_client_dialog_state_transitions() -> crate::Result<()> {
     // Transition to Trying (after sending INVITE)
     client_dialog
         .inner
-        .transition(DialogState::Trying(dialog_id.clone()))?;
+        .transition(DialogState::Trying(dialog_id.clone()));
     let state = client_dialog.inner.state.lock().unwrap().clone();
     assert!(matches!(state, DialogState::Trying(_)));
 
@@ -183,7 +183,7 @@ async fn test_client_dialog_state_transitions() -> crate::Result<()> {
 
     client_dialog
         .inner
-        .transition(DialogState::Early(dialog_id.clone(), ringing_resp.clone()))?;
+        .transition(DialogState::Early(dialog_id.clone(), ringing_resp.clone()));
     let state = client_dialog.inner.state.lock().unwrap().clone();
     assert!(matches!(state, DialogState::Early(_, _)));
 
@@ -192,7 +192,7 @@ async fn test_client_dialog_state_transitions() -> crate::Result<()> {
     // Transition to Confirmed (after receiving 200 OK and sending ACK)
     client_dialog
         .inner
-        .transition(DialogState::Confirmed(dialog_id.clone(), final_resp))?;
+        .transition(DialogState::Confirmed(dialog_id.clone(), final_resp));
     let state = client_dialog.inner.state.lock().unwrap().clone();
     assert!(matches!(state, DialogState::Confirmed(_, _)));
     assert!(client_dialog.inner.is_confirmed());
@@ -234,7 +234,7 @@ async fn test_client_dialog_termination_scenarios() -> crate::Result<()> {
     client_dialog_1.inner.transition(DialogState::Terminated(
         dialog_id_1.clone(),
         TerminatedReason::UasBusy,
-    ))?;
+    ));
 
     let state = client_dialog_1.inner.state.lock().unwrap().clone();
     assert!(matches!(
@@ -270,14 +270,14 @@ async fn test_client_dialog_termination_scenarios() -> crate::Result<()> {
     client_dialog_2.inner.transition(DialogState::Confirmed(
         dialog_id_2.clone(),
         Response::default(),
-    ))?;
+    ));
     assert!(client_dialog_2.inner.is_confirmed());
 
     // Then terminate normally
     client_dialog_2.inner.transition(DialogState::Terminated(
         dialog_id_2.clone(),
         TerminatedReason::UacBye,
-    ))?;
+    ));
     let state = client_dialog_2.inner.state.lock().unwrap().clone();
     assert!(matches!(
         state,

--- a/src/dialog/tests/test_dialog_states.rs
+++ b/src/dialog/tests/test_dialog_states.rs
@@ -139,7 +139,7 @@ async fn test_dialog_state_transitions() -> crate::Result<()> {
     assert!(matches!(initial_state, DialogState::Calling(_)));
 
     // Test transition to Trying
-    dialog_inner.transition(DialogState::Trying(dialog_id.clone()))?;
+    dialog_inner.transition(DialogState::Trying(dialog_id.clone()));
     let state = dialog_inner.state.lock().unwrap().clone();
     assert!(matches!(state, DialogState::Trying(_)));
 
@@ -150,7 +150,7 @@ async fn test_dialog_state_transitions() -> crate::Result<()> {
         "bob-tag-789",
         "test-call-id-123",
     );
-    dialog_inner.transition(DialogState::Early(dialog_id.clone(), ringing_resp))?;
+    dialog_inner.transition(DialogState::Early(dialog_id.clone(), ringing_resp));
     let state = dialog_inner.state.lock().unwrap().clone();
     assert!(matches!(state, DialogState::Early(_, _)));
 
@@ -158,7 +158,7 @@ async fn test_dialog_state_transitions() -> crate::Result<()> {
     dialog_inner.transition(DialogState::Confirmed(
         dialog_id.clone(),
         Response::default(),
-    ))?;
+    ));
     let state = dialog_inner.state.lock().unwrap().clone();
     assert!(matches!(state, DialogState::Confirmed(_, _)));
     assert!(dialog_inner.is_confirmed());
@@ -167,7 +167,7 @@ async fn test_dialog_state_transitions() -> crate::Result<()> {
     dialog_inner.transition(DialogState::Terminated(
         dialog_id.clone(),
         TerminatedReason::Timeout,
-    ))?;
+    ));
     let state = dialog_inner.state.lock().unwrap().clone();
     assert!(matches!(state, DialogState::Terminated(_, _)));
 
@@ -207,7 +207,7 @@ async fn test_server_dialog_state_transitions() -> crate::Result<()> {
     assert!(matches!(initial_state, DialogState::Calling(_)));
 
     // Test transition to Trying (server sends 100 Trying)
-    dialog_inner.transition(DialogState::Trying(dialog_id.clone()))?;
+    dialog_inner.transition(DialogState::Trying(dialog_id.clone()));
     let state = dialog_inner.state.lock().unwrap().clone();
     assert!(matches!(state, DialogState::Trying(_)));
 
@@ -218,12 +218,12 @@ async fn test_server_dialog_state_transitions() -> crate::Result<()> {
         "bob-tag-789",
         "test-call-id-server-123",
     );
-    dialog_inner.transition(DialogState::WaitAck(dialog_id.clone(), ok_resp.clone()))?;
+    dialog_inner.transition(DialogState::WaitAck(dialog_id.clone(), ok_resp.clone()));
     let state = dialog_inner.state.lock().unwrap().clone();
     assert!(matches!(state, DialogState::WaitAck(_, _)));
 
     // Test transition to Confirmed (after receiving ACK)
-    dialog_inner.transition(DialogState::Confirmed(dialog_id.clone(), ok_resp))?;
+    dialog_inner.transition(DialogState::Confirmed(dialog_id.clone(), ok_resp));
     let state = dialog_inner.state.lock().unwrap().clone();
     assert!(matches!(state, DialogState::Confirmed(_, _)));
     assert!(dialog_inner.is_confirmed());
@@ -264,7 +264,7 @@ async fn test_dialog_in_dialog_requests() -> crate::Result<()> {
     dialog_inner.transition(DialogState::Confirmed(
         dialog_id.clone(),
         Response::default(),
-    ))?;
+    ));
     assert!(dialog_inner.is_confirmed());
 
     // Test INFO request in dialog
@@ -284,7 +284,7 @@ async fn test_dialog_in_dialog_requests() -> crate::Result<()> {
     };
 
     let (handle, _) = TransactionHandle::new();
-    dialog_inner.transition(DialogState::Info(dialog_id.clone(), info_req, handle))?;
+    dialog_inner.transition(DialogState::Info(dialog_id.clone(), info_req, handle));
 
     // Test UPDATE request in dialog
     let update_req = Request {
@@ -303,7 +303,7 @@ async fn test_dialog_in_dialog_requests() -> crate::Result<()> {
     };
 
     let (handle, _) = TransactionHandle::new();
-    dialog_inner.transition(DialogState::Updated(dialog_id.clone(), update_req, handle))?;
+    dialog_inner.transition(DialogState::Updated(dialog_id.clone(), update_req, handle));
 
     // Test OPTIONS request in dialog
     let options_req = Request {
@@ -322,7 +322,7 @@ async fn test_dialog_in_dialog_requests() -> crate::Result<()> {
     };
 
     let (handle, _) = TransactionHandle::new();
-    dialog_inner.transition(DialogState::Options(dialog_id.clone(), options_req, handle))?;
+    dialog_inner.transition(DialogState::Options(dialog_id.clone(), options_req, handle));
 
     // Dialog should still be confirmed after in-dialog requests
     assert!(dialog_inner.is_confirmed());
@@ -360,7 +360,7 @@ async fn test_dialog_termination_scenarios() -> crate::Result<()> {
     dialog_inner_1.transition(DialogState::Terminated(
         dialog_id_1.clone(),
         TerminatedReason::UasBusy,
-    ))?;
+    ));
     let state = dialog_inner_1.state.lock().unwrap().clone();
     assert!(matches!(
         state,
@@ -392,14 +392,14 @@ async fn test_dialog_termination_scenarios() -> crate::Result<()> {
     dialog_inner_2.transition(DialogState::Confirmed(
         dialog_id_2.clone(),
         Response::default(),
-    ))?;
+    ));
     assert!(dialog_inner_2.is_confirmed());
 
     // Then terminate normally
     dialog_inner_2.transition(DialogState::Terminated(
         dialog_id_2.clone(),
         TerminatedReason::UacBye,
-    ))?;
+    ));
     let state = dialog_inner_2.state.lock().unwrap().clone();
     assert!(matches!(state, DialogState::Terminated(_, _)));
 


### PR DESCRIPTION
Small simplification which makes rejecting calls return unit instead of `Result<()>`.

I noticed that `DialogInner::transition()` doesn't actually return `Err(_)` ever, so I just changed the return type to unit.

There might be more cases like that in the codebase.