### PR TITLE
fix: clear expire params of Contact

### DIFF
--- a/src/dialog/registration.rs
+++ b/src/dialog/registration.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 use rsip::{
     prelude::{HeadersExt, ToTypedHeader},
-    Response, SipMessage, StatusCode,
+    Param, Response, SipMessage, StatusCode,
 };
 use tracing::debug;
 
@@ -378,7 +378,7 @@ impl Registration {
         // 3. Local non-loopback address (lowest priority)
         //    - Only used for initial registration attempt
         //    - Will be replaced by server-discovered address after first response
-        let contact = self.contact.clone().unwrap_or_else(|| {
+        let mut contact = self.contact.clone().unwrap_or_else(|| {
             let contact_host_with_port = self
                 .public_address
                 .clone()
@@ -395,6 +395,11 @@ impl Registration {
                 params: vec![],
             }
         });
+
+        if expires.is_some() {
+            contact.params.retain(|p| !matches!(p, Param::Expires(_)));
+        }
+
         let mut request = self.endpoint.make_request(
             rsip::Method::Register,
             server,


### PR DESCRIPTION
Current register will save the Contact in the response of Register, which contain an expire paramter. This contact will used for later Register.

Accoring  [RFC 3261 10.2.1.1](https://datatracker.ietf.org/doc/html/rfc3261#section-10.2.1.1) Setting the Expiration Interval of Contact Addresses: 

>   There are two ways in which a client can suggest an expiration
   interval for a binding: through an **Expires header** field or an
   **"expires" Contact header parameter**.  The latter allows expiration
   intervals to be suggested on a per-binding basis when more than one
   binding is given in a single REGISTER request, whereas the former
   suggests an expiration interval for all Contact header field values
   that **do not contain** the "expires" parameter.

Ff they both present, the expire params will override the Expire header.

This broke the unregister.