### PR TITLE
fix: save destination for dialog

### DIFF
--- a/src/dialog/client_dialog.rs
+++ b/src/dialog/client_dialog.rs
@@ -703,6 +703,9 @@ impl ClientInviteDialog {
         self.inner.transition(DialogState::Calling(self.id()))?;
         let mut auth_sent = false;
         tx.send().await?;
+        if let Some(destination) = &tx.destination {
+            *self.inner.remote_uri.lock() = destination.clone().into();
+        }
         let mut dialog_id = self.id();
         let mut final_response = None;
         while let Some(msg) = tx.receive().await {
@@ -745,6 +748,9 @@ impl ClientInviteDialog {
                             )
                             .await?;
                             tx.send().await?;
+                            if let Some(destination) = &tx.destination {
+                                *self.inner.remote_uri.lock() = destination.clone().into();
+                            }
                             self.inner.update_remote_tag("").ok();
                             // Update initial_request with the new invite request
                             {


### PR DESCRIPTION
INVITE transaction may set the destination, but the cancel actually constructed from the remote_uri which constructed from the request uri, and they may be different.

For example, if an sip phone register on a local sip proxy as sip:alice@127.0.0.1 , and then outgoing invite for alice will find the correct addres because of the locator find the actual address, but the cancel will not.