### PR TITLE
Support name-addr Refer-To headers

### DIFF
--- a/src/dialog/client_dialog.rs
+++ b/src/dialog/client_dialog.rs
@@ -471,20 +471,17 @@ impl ClientInviteDialog {
     ///
     /// # Parameters
     ///
-    /// * `refer_to` - The URI to refer to (Refer-To header value)
+    /// * `refer_to` - The full Refer-To header value. `Uri` inputs are serialized as `<uri>`.
     /// * `headers` - Optional additional headers
     /// * `body` - Optional message body
     pub async fn refer(
         &self,
-        refer_to: crate::sip::Uri,
+        refer_to: impl Into<crate::sip::ReferTo>,
         headers: Option<Vec<crate::sip::Header>>,
         body: Option<Vec<u8>>,
     ) -> Result<Option<crate::sip::Response>> {
         let mut headers = headers.unwrap_or_default();
-        headers.push(crate::sip::Header::Other(
-            "Refer-To".into(),
-            format!("<{}>", refer_to),
-        ));
+        headers.push(crate::sip::Header::ReferTo(refer_to.into()));
         self.request(crate::sip::Method::Refer, Some(headers), body)
             .await
     }

--- a/src/dialog/dialog.rs
+++ b/src/dialog/dialog.rs
@@ -1429,7 +1429,7 @@ impl Dialog {
 
     pub async fn refer(
         &self,
-        refer_to: crate::sip::Uri,
+        refer_to: impl Into<crate::sip::ReferTo>,
         headers: Option<Vec<crate::sip::Header>>,
         body: Option<Vec<u8>>,
     ) -> Result<Option<crate::sip::Response>> {

--- a/src/dialog/publication.rs
+++ b/src/dialog/publication.rs
@@ -96,14 +96,12 @@ impl ClientPublicationDialog {
 
     pub async fn refer(
         &self,
-        refer_to: crate::sip::Uri,
+        refer_to: impl Into<crate::sip::ReferTo>,
         headers: Option<Vec<crate::sip::Header>>,
         body: Option<Vec<u8>>,
     ) -> Result<Option<crate::sip::Response>> {
         let mut headers = headers.unwrap_or_default();
-        headers.push(crate::sip::Header::ReferTo(
-            format!("<{}>", refer_to).into(),
-        ));
+        headers.push(crate::sip::Header::ReferTo(refer_to.into()));
         self.request(crate::sip::Method::Refer, Some(headers), body)
             .await
     }
@@ -229,14 +227,12 @@ impl ServerPublicationDialog {
 
     pub async fn refer(
         &self,
-        refer_to: crate::sip::Uri,
+        refer_to: impl Into<crate::sip::ReferTo>,
         headers: Option<Vec<crate::sip::Header>>,
         body: Option<Vec<u8>>,
     ) -> Result<Option<crate::sip::Response>> {
         let mut headers = headers.unwrap_or_default();
-        headers.push(crate::sip::Header::ReferTo(
-            format!("<{}>", refer_to).into(),
-        ));
+        headers.push(crate::sip::Header::ReferTo(refer_to.into()));
         self.request(crate::sip::Method::Refer, Some(headers), body)
             .await
     }

--- a/src/dialog/server_dialog.rs
+++ b/src/dialog/server_dialog.rs
@@ -552,15 +552,12 @@ impl ServerInviteDialog {
     /// Send a REFER request
     pub async fn refer(
         &self,
-        refer_to: crate::sip::Uri,
+        refer_to: impl Into<crate::sip::ReferTo>,
         headers: Option<Vec<crate::sip::Header>>,
         body: Option<Vec<u8>>,
     ) -> Result<Option<crate::sip::Response>> {
         let mut headers = headers.unwrap_or_default();
-        headers.push(crate::sip::Header::Other(
-            "Refer-To".into(),
-            format!("<{}>", refer_to),
-        ));
+        headers.push(crate::sip::Header::ReferTo(refer_to.into()));
         self.request(crate::sip::Method::Refer, Some(headers), body)
             .await
     }

--- a/src/dialog/subscription.rs
+++ b/src/dialog/subscription.rs
@@ -58,14 +58,12 @@ impl ClientSubscriptionDialog {
 
     pub async fn refer(
         &self,
-        refer_to: crate::sip::Uri,
+        refer_to: impl Into<crate::sip::ReferTo>,
         headers: Option<Vec<crate::sip::Header>>,
         body: Option<Vec<u8>>,
     ) -> Result<Option<crate::sip::Response>> {
         let mut headers = headers.unwrap_or_default();
-        headers.push(crate::sip::Header::ReferTo(
-            format!("<{}>", refer_to).into(),
-        ));
+        headers.push(crate::sip::Header::ReferTo(refer_to.into()));
         self.request(crate::sip::Method::Refer, Some(headers), body)
             .await
     }
@@ -193,14 +191,12 @@ impl ServerSubscriptionDialog {
 
     pub async fn refer(
         &self,
-        refer_to: crate::sip::Uri,
+        refer_to: impl Into<crate::sip::ReferTo>,
         headers: Option<Vec<crate::sip::Header>>,
         body: Option<Vec<u8>>,
     ) -> Result<Option<crate::sip::Response>> {
         let mut headers = headers.unwrap_or_default();
-        headers.push(crate::sip::Header::ReferTo(
-            format!("<{}>", refer_to).into(),
-        ));
+        headers.push(crate::sip::Header::ReferTo(refer_to.into()));
         self.request(crate::sip::Method::Refer, Some(headers), body)
             .await
     }

--- a/src/dialog/tests/mod.rs
+++ b/src/dialog/tests/mod.rs
@@ -3,5 +3,6 @@ mod test_client_dialog;
 mod test_dialog_layer;
 mod test_dialog_states;
 mod test_prack;
+mod test_refer;
 mod test_server_dialog;
 mod test_sub_pub;

--- a/src/dialog/tests/test_refer.rs
+++ b/src/dialog/tests/test_refer.rs
@@ -1,0 +1,54 @@
+use std::sync::Arc;
+
+use tokio::sync::mpsc::unbounded_channel;
+
+use crate::dialog::{client_dialog::ClientInviteDialog, dialog::DialogInner, DialogId};
+use crate::sip::{ReferTo, Uri};
+use crate::transaction::key::TransactionRole;
+
+use super::test_dialog_states::{create_invite_request, create_test_endpoint};
+
+#[test]
+fn test_refer_to_from_uri_preserves_existing_uri_behavior() -> crate::Result<()> {
+    let refer_to = ReferTo::from(Uri::try_from("sip:carol@restsend.com")?);
+    assert_eq!(refer_to.value(), "<sip:carol@restsend.com>");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_client_dialog_refer_accepts_name_addr_values() -> crate::Result<()> {
+    let endpoint = create_test_endpoint().await?;
+    let (state_sender, _) = unbounded_channel();
+
+    let dialog_id = DialogId {
+        call_id: "refer-name-addr".to_string(),
+        local_tag: "alice-tag".to_string(),
+        remote_tag: "bob-tag".to_string(),
+    };
+
+    let invite_req = create_invite_request("alice-tag", "bob-tag", "refer-name-addr");
+    let (tu_sender, _tu_receiver) = unbounded_channel();
+
+    let dialog_inner = DialogInner::new(
+        TransactionRole::Client,
+        dialog_id,
+        invite_req,
+        endpoint.inner.clone(),
+        state_sender,
+        None,
+        Some(Uri::try_from("sip:alice@alice.example.com:5060")?),
+        tu_sender,
+    )?;
+
+    let client_dialog = ClientInviteDialog {
+        inner: Arc::new(dialog_inner),
+    };
+
+    std::mem::drop(client_dialog.refer(
+        "\"Display Name\" <sip:user@domain.com;method=INVITE?Replaces=call-id%40host>",
+        None,
+        None,
+    ));
+
+    Ok(())
+}

--- a/src/sip/headers/untyped.rs
+++ b/src/sip/headers/untyped.rs
@@ -173,6 +173,12 @@ untyped_header!(Privacy, "Privacy", Header::Privacy);
 untyped_header!(Path, "Path", Header::Path);
 untyped_header!(Identity, "Identity", Header::Identity);
 
+impl std::convert::From<crate::sip::Uri> for ReferTo {
+    fn from(uri: crate::sip::Uri) -> Self {
+        Self(format!("<{}>", uri))
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 pub struct CallId(pub String);
 impl CallId {


### PR DESCRIPTION
## What changed

This updates the dialog `refer()` APIs to accept full `Refer-To` header values instead of only `Uri` inputs.

- widen `refer()` to accept `impl Into<crate::sip::ReferTo>` across dialog types
- add `From<crate::sip::Uri> for ReferTo` so existing URI callers still serialize as `<sip:...>`
- add focused tests for both URI compatibility and raw name-addr input

## Why it changed

Issue #115 points out that RFC 3515 allows `Refer-To` to carry the full name-addr form, including an optional display name and parameters. The previous API only accepted `Uri` and always forced `Refer-To` into `"<uri>"`, which prevented callers from supplying valid name-addr values.

## Impact

- existing callers that pass `Uri` continue to work unchanged
- callers can now pass a full `Refer-To` value such as `"Display Name" <sip:user@domain.com;method=INVITE?Replaces=...>`
- downstream REFER-related tests in sibling repos continue to pass against this local branch

## Root cause

The REFER helpers modeled `Refer-To` as a URI-only input even though the header syntax is wider than a bare URI.

## Validation

- `cargo test --lib`
- `cargo test refer` in `active-call`
- `cargo test test_inbound_refer_success --lib` in `rustpbx`
- `cargo test --test rwi_transfer_refer_e2e_test` in `rustpbx`

Closes #115.
