### PR TITLE
Replace unmaintained dotenv with dotenvy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ tokio = { version = "1.50.0", features = ["time", "sync", "macros", "io-util"] }
 tokio = { version = "1.50.0", features = ["full"] }
 
 [dev-dependencies]
-dotenv = "0.15"
+dotenvy = "0.15.7"
 tempfile = "3"
 sdp-rs = "0.2.1"
 rtp-rs = "0.6.0"

--- a/examples/client/main.rs
+++ b/examples/client/main.rs
@@ -141,7 +141,7 @@ async fn main() -> rsipstack::Result<()> {
         .try_init()
         .ok();
 
-    if let Err(e) = dotenv::dotenv() {
+    if let Err(e) = dotenvy::dotenv() {
         info!(error = %e, "Failed to load .env file");
     }
 

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -95,7 +95,7 @@ async fn main() -> Result<()> {
         .with_line_number(true)
         .try_init()
         .ok();
-    if let Err(e) = dotenv::dotenv() {
+    if let Err(e) = dotenvy::dotenv() {
         info!(error = %e, "Failed to load .env file");
     }
     let args = Args::parse();


### PR DESCRIPTION
Fixes https://rustsec.org/advisories/RUSTSEC-2021-0141

See https://github.com/dotenv-rs/dotenv/issues/74 for reference