### PR TITLE
fix: preserve binary message bodies when serializing to the wire

### DIFF
--- a/src/sip/message.rs
+++ b/src/sip/message.rs
@@ -360,6 +360,29 @@ impl std::fmt::Display for Request {
     }
 }
 
+impl Request {
+    /// Serialize the request to its on-the-wire byte representation.
+    ///
+    /// The request line and headers are ASCII; the body is appended verbatim.
+    /// A SIP message body is an opaque octet sequence (RFC 3261 §7.4) and may
+    /// contain arbitrary bytes — e.g. a binary ISUP part or an eCall MSD — so
+    /// it must not be forced through UTF-8.
+    ///
+    /// Prefer this over [`Display`](std::fmt::Display) / `to_string()` when
+    /// putting a message on the wire: `Display` renders the body with
+    /// [`String::from_utf8_lossy`], which is fine for logging but corrupts
+    /// non-UTF-8 bytes.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let head = format!(
+            "{} {} {}\r\n{}\r\n",
+            self.method, self.uri, self.version, self.headers
+        );
+        let mut buf = head.into_bytes();
+        buf.extend_from_slice(&self.body);
+        buf
+    }
+}
+
 impl std::convert::TryFrom<Vec<u8>> for Request {
     type Error = Error;
     fn try_from(bytes: Vec<u8>) -> Result<Self, Error> {
@@ -406,7 +429,7 @@ impl std::convert::From<Request> for String {
 
 impl std::convert::From<Request> for Vec<u8> {
     fn from(r: Request) -> Vec<u8> {
-        r.to_string().into_bytes()
+        r.to_bytes()
     }
 }
 
@@ -507,6 +530,25 @@ impl std::fmt::Display for Response {
     }
 }
 
+impl Response {
+    /// Serialize the response to its on-the-wire byte representation.
+    ///
+    /// See [`Request::to_bytes`]: the body is written verbatim because a SIP
+    /// body is an opaque octet sequence (RFC 3261 §7.4), not necessarily UTF-8.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let head = format!(
+            "{} {} {}\r\n{}\r\n",
+            self.version,
+            self.status_code.code(),
+            self.status_code.text(),
+            self.headers
+        );
+        let mut buf = head.into_bytes();
+        buf.extend_from_slice(&self.body);
+        buf
+    }
+}
+
 impl std::convert::TryFrom<Vec<u8>> for Response {
     type Error = Error;
     fn try_from(bytes: Vec<u8>) -> Result<Self, Error> {
@@ -553,7 +595,7 @@ impl std::convert::From<Response> for String {
 
 impl std::convert::From<Response> for Vec<u8> {
     fn from(r: Response) -> Vec<u8> {
-        r.to_string().into_bytes()
+        r.to_bytes()
     }
 }
 
@@ -601,6 +643,19 @@ impl std::fmt::Display for SipMessage {
         match self {
             SipMessage::Request(r) => write!(f, "{}", r),
             SipMessage::Response(r) => write!(f, "{}", r),
+        }
+    }
+}
+
+impl SipMessage {
+    /// Serialize the message to its on-the-wire byte representation.
+    ///
+    /// See [`Request::to_bytes`]. Transports should use this rather than
+    /// `to_string()` so binary bodies are preserved byte-for-byte.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            SipMessage::Request(r) => r.to_bytes(),
+            SipMessage::Response(r) => r.to_bytes(),
         }
     }
 }
@@ -673,7 +728,7 @@ impl std::convert::From<SipMessage> for String {
 
 impl std::convert::From<SipMessage> for Vec<u8> {
     fn from(m: SipMessage) -> Vec<u8> {
-        m.to_string().into_bytes()
+        m.to_bytes()
     }
 }
 
@@ -765,6 +820,39 @@ mod tests {
         let resp: Response = ok_response().try_into().unwrap();
         assert_eq!(resp.status_code.code(), 200);
         assert_eq!(resp.body, b"v=0\r\no=bob 2890844527 2890844527 IN IP4 192.0.2.4\r\ns=-\r\nc=IN IP4 192.0.2.4\r\nt=0 0\r\nm=audio 3456 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000");
+    }
+
+    #[test]
+    fn request_binary_body_survives_serialization() {
+        // A SIP message body is an opaque octet payload (RFC 3261 §7.4), not
+        // necessarily UTF-8 text. e.g. an NG-eCall INVITE carries a binary
+        // ASN.1 PER-encoded MSD. Serialization to the wire must preserve every
+        // byte, including bytes that are invalid as UTF-8.
+        let mut req: Request = invite_request().try_into().unwrap();
+        let binary_body: Vec<u8> = vec![0x00, 0x01, 0x80, 0xFF, 0xC0, 0xC1, 0xFE, 0x02, 0x7F, 0x90];
+        req.body = binary_body.clone();
+
+        let wire: Vec<u8> = req.into();
+
+        assert!(
+            wire.ends_with(&binary_body),
+            "binary body corrupted during serialization: got tail {:?}",
+            &wire[wire.len().saturating_sub(binary_body.len() + 4)..]
+        );
+    }
+
+    #[test]
+    fn response_binary_body_survives_serialization() {
+        let mut resp: Response = ok_response().try_into().unwrap();
+        let binary_body: Vec<u8> = vec![0x00, 0x80, 0xFF, 0xC0, 0xC1, 0xFE, 0x02];
+        resp.body = binary_body.clone();
+
+        let wire: Vec<u8> = resp.into();
+
+        assert!(
+            wire.ends_with(&binary_body),
+            "binary body corrupted during serialization"
+        );
     }
 
     #[test]

--- a/src/transport/stream.rs
+++ b/src/transport/stream.rs
@@ -136,8 +136,9 @@ impl Encoder<SipMessage> for SipCodec {
     type Error = crate::Error;
 
     fn encode(&mut self, item: SipMessage, dst: &mut BytesMut) -> Result<()> {
-        let data = item.to_string();
-        dst.extend_from_slice(data.as_bytes());
+        // Use to_bytes() (not to_string()) so binary bodies are preserved
+        // byte-for-byte; a SIP body is opaque octets (RFC 3261 §7.4).
+        dst.extend_from_slice(&item.to_bytes());
         Ok(())
     }
 }
@@ -264,7 +265,7 @@ pub async fn send_to_stream<W>(write_half: &Mutex<W>, msg: SipMessage) -> Result
 where
     W: AsyncWrite + Unpin + Send,
 {
-    send_raw_to_stream(write_half, msg.to_string().as_bytes()).await
+    send_raw_to_stream(write_half, &msg.to_bytes()).await
 }
 
 pub async fn send_raw_to_stream<W>(write_half: &Mutex<W>, data: &[u8]) -> Result<()>
@@ -322,6 +323,29 @@ mod tests {
         )
         .as_bytes()
         .to_vec()
+    }
+
+    // ── binary body ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn encode_preserves_binary_body() {
+        use crate::sip::{Request, SipMessage};
+        // A SIP body is opaque octets (RFC 3261 §7.4); the stream codec must
+        // emit it byte-for-byte, including bytes that are invalid as UTF-8.
+        let mut req: Request = invite_bytes("").as_slice().try_into().unwrap();
+        let binary_body: Vec<u8> = vec![0x00, 0x80, 0xFF, 0xC0, 0xC1, 0xFE, 0x01, 0x7F];
+        req.body = binary_body.clone();
+
+        let mut codec = make_codec();
+        let mut dst = BytesMut::new();
+        codec
+            .encode(SipMessage::Request(req), &mut dst)
+            .expect("encode");
+
+        assert!(
+            dst.ends_with(&binary_body),
+            "stream codec corrupted binary body"
+        );
     }
 
     // ── 基本解码 ──────────────────────────────────────────────────────────────

--- a/src/transport/udp.rs
+++ b/src/transport/udp.rs
@@ -211,13 +211,15 @@ impl UdpConnection {
             Some(addr) => addr.get_socketaddr(),
             None => SipConnection::get_destination(&msg),
         }?;
-        let buf = msg.to_string();
+        // Use to_bytes() (not to_string()) so binary bodies are preserved
+        // byte-for-byte; a SIP body is opaque octets (RFC 3261 §7.4).
+        let buf = msg.to_bytes();
 
-        debug!(len=buf.len(), dest=%destination, src=%self.get_addr(), raw_message=buf, "udp send");
+        debug!(len=buf.len(), dest=%destination, src=%self.get_addr(), raw_message=%msg, "udp send");
 
         self.inner
             .conn
-            .send_to(buf.as_bytes(), destination)
+            .send_to(&buf, destination)
             .await
             .map_err(|e| {
                 crate::Error::TransportLayerError(e.to_string(), self.get_addr().to_owned())


### PR DESCRIPTION
## Summary

SIP message bodies are opaque octets (RFC 3261 §7.4), but `rsipstack` serialized them as UTF-8 text, corrupting any body that isn't valid UTF-8. This makes `to_bytes()` the canonical wire serializer (preserving the body verbatim) and routes the UDP/TCP/TLS transports through it.

## Problem

A message with a binary body, e.g. an `application/ISUP` part, or an eCall MSD (binary ASN.1 PER), is sent with the body mangled. Every non-UTF-8 byte is replaced by `U+FFFD` (`EF BF BD`), which both changes the payload and breaks `Content-Length`.

## Root cause

All message→bytes paths went through `Display`/`to_string()`, which renders the body with `String::from_utf8_lossy`:

```rust
// src/sip/message.rs (Display for Request/Response)
write!(f, "...{}\r\n{}", self.headers, String::from_utf8_lossy(&self.body))
```

and the transports serialized via `to_string()` (`transport/udp.rs`, `transport/stream.rs`).

Notably, the receive path already preserves binary bodies (the parser slices the body by `Content-Length`), so send and receive were asymmetric.

## Fix

- Add `to_bytes()` to `Request`, `Response`, and `SipMessage`: start line + headers as ASCII, body appended verbatim.
- `From<…> for Vec<u8>` now delegates to `to_bytes()`.
- UDP `send`, the TCP/TLS `SipCodec` encoder, and `send_to_stream` use `to_bytes()`.

## Scope

WebSocket transport is intentionally unchanged: SIP-over-WS (RFC 7118 §5) uses UTF-8 text frames, so binary bodies aren't representable there regardless.

## Testing

- New regression tests: a `Request`/`Response` round-trip and the stream codec, each asserting a non-UTF-8 body survives serialization byte-for-byte.
- Full suite: `cargo test --lib` → 238 passed, clippy clean.

## Compatibility

Backward compatible. `Display`/`to_string()` behaviour is unchanged; only the byte serialization used by transports is corrected.
