### PR TITLE
fix: make serve_listens idempotent to avoid duplicate bind AddrInUse

### DIFF
--- a/src/transport/transport_layer.rs
+++ b/src/transport/transport_layer.rs
@@ -8,7 +8,7 @@ use crate::transport::connection::TransportReceiver;
 use crate::{transport::TransportEvent, Result};
 use async_trait::async_trait;
 use parking_lot::{Mutex, RwLock};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::sync::Arc;
 use tokio::select;
@@ -100,6 +100,7 @@ impl DomainResolver for DefaultDomainResolver {
 pub struct TransportLayerInner {
     pub(crate) cancel_token: CancellationToken,
     listens: Arc<RwLock<Vec<SipConnection>>>, // listening transports
+    served_listens: Mutex<HashSet<SipAddr>>,  // addresses already being served
     connections: Arc<RwLock<HashMap<SipAddr, SipConnection>>>, // outbound/inbound connections
     pub(crate) transport_tx: TransportSender,
     pub(crate) transport_rx: Mutex<Option<TransportReceiver>>,
@@ -124,6 +125,7 @@ impl TransportLayer {
         let inner = TransportLayerInner {
             cancel_token,
             listens: Arc::new(RwLock::new(Vec::new())),
+            served_listens: Mutex::new(HashSet::new()),
             connections: Arc::new(RwLock::new(HashMap::new())),
             transport_tx,
             transport_rx: Mutex::new(Some(transport_rx)),
@@ -166,6 +168,10 @@ impl TransportLayer {
         self.inner.lookup(target, self.outbound.as_ref(), key).await
     }
 
+    /// Serve all registered listeners. Idempotent: listeners whose address is
+    /// already being served are skipped, so calling this explicitly before
+    /// `Endpoint::serve()` (which also calls it) does not attempt a duplicate
+    /// bind that would fail with AddrInUse.
     pub async fn serve_listens(&self) -> Result<()> {
         let listens = self.inner.listens.read().clone();
         for transport in listens {
@@ -246,6 +252,7 @@ impl TransportLayerInner {
 
     pub(super) fn del_listener(&self, addr: &SipAddr) {
         self.listens.write().retain(|t| t.get_addr() != addr);
+        self.served_listens.lock().remove(addr);
     }
 
     pub(super) fn add_connection(&self, connection: SipConnection) {
@@ -354,8 +361,13 @@ impl TransportLayerInner {
     }
 
     pub(super) async fn serve_listener(self: Arc<Self>, transport: SipConnection) -> Result<()> {
+        let addr = transport.get_addr().clone();
+        if !self.served_listens.lock().insert(addr.clone()) {
+            debug!(%addr, "listener already served, skipping");
+            return Ok(());
+        }
         let sender = self.transport_tx.clone();
-        match transport {
+        let result = match transport {
             SipConnection::Udp(transport) => {
                 let transport_layer_inner = self.clone();
                 tokio::spawn(async move {
@@ -380,7 +392,11 @@ impl TransportLayerInner {
                 );
                 Ok(())
             }
+        };
+        if result.is_err() {
+            self.served_listens.lock().remove(&addr);
         }
+        result
     }
 
     pub fn serve_connection(&self, transport: SipConnection) {
@@ -428,7 +444,7 @@ mod tests {
     use crate::sip::uri::ParamsExt;
     use crate::sip::{Host, HostWithPort, Transport};
     use crate::{
-        transport::{udp::UdpConnection, SipAddr},
+        transport::{tcp_listener::TcpListenerConnection, udp::UdpConnection, SipAddr},
         Result,
     };
 
@@ -551,6 +567,44 @@ mod tests {
         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
         drop(tl);
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_serve_listener_is_idempotent() -> Result<()> {
+        let tl = super::TransportLayer::new(tokio_util::sync::CancellationToken::new());
+
+        // Reserve a concrete port so a duplicate bind on it would fail
+        let probe = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let local_addr = probe.local_addr()?;
+        drop(probe);
+
+        let listener = TcpListenerConnection::new(
+            SipAddr {
+                r#type: Some(Transport::Tcp),
+                addr: local_addr.into(),
+            },
+            None,
+        )
+        .await?;
+        let connection: super::SipConnection = listener.into();
+        tl.add_transport(connection.clone());
+
+        // First serve binds the listener
+        super::TransportLayerInner::serve_listener(tl.inner.clone(), connection.clone()).await?;
+
+        // Serving the same listener again must be a no-op instead of a
+        // second bind that fails with AddrInUse
+        super::TransportLayerInner::serve_listener(tl.inner.clone(), connection.clone()).await?;
+
+        // The listener must still accept connections
+        tokio::net::TcpStream::connect(local_addr).await?;
+
+        // Removing the listener frees its address for a future serve
+        tl.del_transport(connection.get_addr());
+        assert!(tl.inner.served_listens.lock().is_empty());
+
+        drop(tl);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Calling `serve_listens()` more than once re-binds every listener socket and fails with `AddrInUse`. 
Since `Endpoint::serve()` already calls `serve_listens()` internally, any application that also calls it explicitly serves everything twice and logs a spurious warning on every startup. This makes listener serving idempotent: an address that is already being served is skipped.

## Problem

An application may call `serve_listens()` before spawning `Endpoint::serve()`, to guarantee listeners are bound before a peer can connect (otherwise there is a race in the gap before the `serve()` task is polled). `serve()` then calls `serve_listens()` again via `process_transport_layer()`, and every listener is served a second time:

    WARN Failed to serve listener error=IoError(Os { code: 98, kind: AddrInUse, message: "Address already in use" }) addr=TCP 127.0.0.1:5060

The first listener wins and handles all traffic, so this is pure log noise - but it is indistinguishable from a real bind failure.

## Root cause

`TcpListenerConnection::new()` only stores the address; the actual `bind()`+`listen()` happen inside `serve_listener()` on every call (`transport/tcp_listener.rs`, same for the TLS and WebSocket listeners):

    // serve_listener(), runs on EVERY call
    let socket = Socket::new(domain, Type::STREAM, Some(Protocol::TCP))?;
    socket.set_reuse_address(true) ...
    socket.bind(&local.into())?;
    socket.listen(128)?;

`SO_REUSEADDR` does not permit two live listeners on the same (ip, port) on Linux (that would need `SO_REUSEPORT`), so the second bind fails with `EADDRINUSE`.
Nothing tracks whether a listener is already being served; for UDP a duplicate serve even spawns a second `serve_loop` on the same socket.

## Fix

- Track served listener addresses in a `served_listens: Mutex<HashSet<SipAddr>>`  on `TransportLayerInner`.
- `serve_listener()` returns early with `Ok` when the address is already served (check-and-insert under one lock, so concurrent calls cannot both proceed).
- A failed serve removes the address again, so a genuine bind failure can be retried.
- `del_listener()` also clears the address, so a listener re-added on the same address is served again.

## Testing

- New regression test `test_serve_listener_is_idempotent`: serves the same TCP listener twice on a fixed port and asserts the second call is a no-op `Ok` (failed with `AddrInUse` before the fix), then verifies the listener still accepts connections and that `del_listener` clears the tracking entry.
- Full suite: `cargo test` -> 304 passed, clippy clean, fmt clean.
- Verified in a real SIP client/server application: the startup warning is gone and TCP call flow (INVITE -> answer -> BYE) is unchanged.

## Compatibility

Backward compatible. `serve_listens()` keeps its signature and still returns `Ok`; the only behavioural change is in the duplicate-serve case, which previously failed with a logged warning and now skips silently.