### PR TITLE
fix(dialog): warn when ServerInviteDialog::bye is skipped

### DIFF
--- a/src/dialog/server_dialog.rs
+++ b/src/dialog/server_dialog.rs
@@ -350,6 +350,16 @@ impl ServerInviteDialog {
     /// * `Err(Error)` - Failed to build/send BYE request.
     pub async fn bye_with_headers(&self, headers: Option<Vec<crate::sip::Header>>) -> Result<()> {
         if !self.inner.is_confirmed() && !self.inner.waiting_ack() {
+            // Silent success here is a footgun for B2BUA hangup paths: callers
+            // cannot tell BYE was never sent. Log when we skip so operators can
+            // correlate stuck endpoints with dialog state divergence.
+            if !self.inner.is_terminated() {
+                warn!(
+                    id = %self.id(),
+                    state = %self.state(),
+                    "bye skipped: dialog not Confirmed/WaitAck"
+                );
+            }
             return Ok(());
         }
 


### PR DESCRIPTION
## Summary
- When `ServerInviteDialog::bye_with_headers` skips sending because the dialog is not `Confirmed`/`WaitAck`, emit a **warning** with dialog id and state (unless already terminated).
- Keeps the return type / `Ok(())` behavior (non-breaking) while making the silent no-op observable.

Addresses #136

## Test plan
- [ ] `bye()` on Confirmed dialog still sends BYE (no new warn)
- [ ] `bye()` on Early/Calling dialog logs warn and still returns Ok
- [ ] `bye()` on Terminated dialog stays quiet