### PR TITLE
Resolve cargo fmt failure

### DIFF
--- a/src/transaction/tests/test_server_invite_drop.rs
+++ b/src/transaction/tests/test_server_invite_drop.rs
@@ -23,7 +23,10 @@ use tokio_util::sync::CancellationToken;
 struct NoopResolver;
 #[async_trait::async_trait]
 impl DomainResolver for NoopResolver {
-    async fn resolve(&self, _target: &crate::transport::SipAddr) -> Result<crate::transport::SipAddr> {
+    async fn resolve(
+        &self,
+        _target: &crate::transport::SipAddr,
+    ) -> Result<crate::transport::SipAddr> {
         Err(crate::Error::DnsResolutionError("noop resolver".into()))
     }
 }


### PR DESCRIPTION
This just reformats part of a test which didn't pass `cargo fmt`.