### PR TITLE
Derive Listener Transport from Type of Listener Being Created

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,8 @@ connection
 ### 2. Using Transport Listeners
 
 ```rust
-use rsipstack::sip::{HostWithPort, Transport};
 use rsipstack::transport::{
-    SipAddr, TcpListenerConnection, TransportEvent, TransportLayer,
+    TcpListenerConnection, TransportEvent, TransportLayer,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -116,10 +115,7 @@ let cancel_token = CancellationToken::new();
 let transport_layer = TransportLayer::new(cancel_token.clone());
 
 let tcp_listener = TcpListenerConnection::new(
-    SipAddr::new(
-        Transport::Tcp,
-        HostWithPort::try_from("0.0.0.0:5060")?,
-    ),
+    "0.0.0.0:5060".parse()?,
     None,
 )
 .await?;

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -134,20 +134,15 @@ async fn main() -> Result<()> {
     info!(addr = %addr, port = args.port, "Added UDP transport");
 
     if let Some(tcp_port) = args.tcp_port {
-        let local_addr = SipAddr {
-            addr: format!("{}:{}", addr, tcp_port)
-                .parse::<std::net::SocketAddr>()?
-                .into(),
-            r#type: Some(rsip::transport::Transport::Tcp),
-        };
+        let local_addr = format!("{}:{}", addr, tcp_port).parse::<std::net::SocketAddr>()?;
         let external_addr = if !external_ip.is_empty() {
             Some(format!("{}:{}", external_ip, tcp_port).parse::<std::net::SocketAddr>()?)
         } else {
             None
         };
-        let tcp_listener = TcpListenerConnection::new(local_addr.clone(), external_addr).await?;
+        let tcp_listener = TcpListenerConnection::new(local_addr, external_addr).await?;
         transport_layer.add_transport(tcp_listener.into());
-        info!(addr = %local_addr.addr, "Added TCP transport");
+        info!(addr = %local_addr, "Added TCP transport");
     }
 
     let endpoint = EndpointBuilder::new()
@@ -183,26 +178,21 @@ async fn main() -> Result<()> {
     if let Some(ws_port) = args.ws_port {
         #[cfg(feature = "websocket")]
         {
-            let local_addr = SipAddr {
-                addr: format!("{}:{}", addr, ws_port)
-                    .parse::<std::net::SocketAddr>()?
-                    .into(),
-                r#type: Some(rsip::transport::Transport::Ws),
-            };
+            let local_addr = format!("{}:{}", addr, ws_port).parse::<std::net::SocketAddr>()?;
             let external_addr = if !external_ip.is_empty() {
                 Some(format!("{}:{}", external_ip, ws_port).parse::<std::net::SocketAddr>()?)
             } else {
                 None
             };
             let ws_listener =
-                WebSocketListenerConnection::new(local_addr.clone(), external_addr, false).await?;
+                WebSocketListenerConnection::new(local_addr, external_addr, false).await?;
             app_state
                 .inner
                 .endpoint_ref
                 .transport_layer
                 .add_transport(ws_listener.into());
 
-            info!(addr = %local_addr.addr, "Added WebSocket transport");
+            info!(addr = %local_addr, "Added WebSocket transport");
         }
         #[cfg(not(feature = "websocket"))]
         {

--- a/src/dialog/tests/test_dialog_layer.rs
+++ b/src/dialog/tests/test_dialog_layer.rs
@@ -12,6 +12,8 @@ use crate::transaction::{
 use crate::transport::{
     tcp_listener::TcpListenerConnection, udp::UdpConnection, SipAddr, TransportLayer,
 };
+#[cfg(feature = "rustls")]
+use crate::transport::{TlsConfig, TlsListenerConnection};
 use tokio::sync::mpsc::unbounded_channel;
 use tokio_util::sync::CancellationToken;
 
@@ -409,16 +411,8 @@ async fn test_server_invite_dialog_with_tcp_transport() -> crate::Result<()> {
     let dialog_layer = DialogLayer::new(endpoint.inner.clone());
 
     // Create a TCP listener connection (without binding a socket)
-    let tcp_addr = SipAddr {
-        r#type: Some(Transport::Tcp),
-        addr: HostWithPort {
-            host: crate::sip::Host::IpAddr(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
-                127, 0, 0, 1,
-            ))),
-            port: Some(5060.into()),
-        },
-    };
-    let tcp_listener = TcpListenerConnection::new(tcp_addr.clone(), None).await?;
+    let tcp_addr = "127.0.0.1:5060".parse()?;
+    let tcp_listener = TcpListenerConnection::new(tcp_addr, None).await?;
     let conn: crate::transport::SipConnection = tcp_listener.into();
 
     // Create INVITE request
@@ -459,16 +453,8 @@ async fn test_make_invite_request_with_tcp_transport() -> crate::Result<()> {
     let tl = TransportLayer::new(token.child_token());
 
     // Add a TCP listener address to the transport layer
-    let tcp_addr = SipAddr {
-        r#type: Some(Transport::Tcp),
-        addr: HostWithPort {
-            host: crate::sip::Host::IpAddr(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
-                192, 168, 1, 10,
-            ))),
-            port: Some(5060.into()),
-        },
-    };
-    let tcp_listener = TcpListenerConnection::new(tcp_addr.clone(), None).await?;
+    let tcp_addr = "192.168.1.10:5060".parse()?;
+    let tcp_listener = TcpListenerConnection::new(tcp_addr, None).await?;
     tl.add_transport(crate::transport::SipConnection::TcpListener(tcp_listener));
 
     let endpoint = EndpointBuilder::new()
@@ -500,7 +486,8 @@ async fn test_make_invite_request_with_tcp_transport() -> crate::Result<()> {
     // Verify Contact header has the transport layer's TCP address and transport param
     let contact = request.contact_header()?.typed()?;
     assert_eq!(
-        contact.uri.host_with_port, tcp_addr.addr,
+        contact.uri.host_with_port,
+        tcp_addr.into(),
         "Contact URI should use the transport layer's TCP address"
     );
     assert!(
@@ -555,23 +542,16 @@ async fn test_make_invite_request_without_transport_uses_contact_as_is() -> crat
     Ok(())
 }
 
+#[cfg(feature = "rustls")]
 #[tokio::test]
 async fn test_make_invite_request_with_tls_transport_uses_sips_scheme() -> crate::Result<()> {
     let token = CancellationToken::new();
     let tl = TransportLayer::new(token.child_token());
 
     // Add a TLS listener address
-    let tls_addr = SipAddr {
-        r#type: Some(Transport::Tls),
-        addr: HostWithPort {
-            host: crate::sip::Host::IpAddr(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
-                192, 168, 1, 10,
-            ))),
-            port: Some(5061.into()),
-        },
-    };
-    let tcp_listener = TcpListenerConnection::new(tls_addr.clone(), None).await?;
-    tl.add_transport(crate::transport::SipConnection::TcpListener(tcp_listener));
+    let tls_addr = "192.168.1.10:5061".parse()?;
+    let tls_listener = TlsListenerConnection::new(tls_addr, None, TlsConfig::default()).await?;
+    tl.add_transport(crate::transport::SipConnection::TlsListener(tls_listener));
 
     let endpoint = EndpointBuilder::new()
         .with_user_agent("rsipstack-test")

--- a/src/transport/connection.rs
+++ b/src/transport/connection.rs
@@ -524,13 +524,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_transport_tcp_listener_returns_tcp() -> crate::Result<()> {
-        let addr = SipAddr {
-            r#type: Some(Transport::Tcp),
-            addr: HostWithPort {
-                host: crate::sip::Host::IpAddr(std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))),
-                port: Some(5060.into()),
-            },
-        };
+        let addr = SocketAddr::from((Ipv4Addr::new(127, 0, 0, 1), 5060));
         let listener = TcpListenerConnection::new(addr, None).await?;
         let sip_conn = SipConnection::TcpListener(listener);
         assert_eq!(sip_conn.transport(), Transport::Tcp);

--- a/src/transport/tcp_listener.rs
+++ b/src/transport/tcp_listener.rs
@@ -19,9 +19,12 @@ pub struct TcpListenerConnection {
 }
 
 impl TcpListenerConnection {
-    pub async fn new(local_addr: SipAddr, external: Option<SocketAddr>) -> Result<Self> {
+    pub async fn new(local_addr: SocketAddr, external: Option<SocketAddr>) -> Result<Self> {
         let inner = TcpListenerConnectionInner {
-            local_addr,
+            local_addr: SipAddr {
+                r#type: Some(crate::sip::transport::Transport::Tcp),
+                addr: local_addr.into(),
+            },
             external: external.map(|addr| SipAddr {
                 r#type: Some(crate::sip::transport::Transport::Tcp),
                 addr: addr.into(),

--- a/src/transport/tests/test_listener_api.rs
+++ b/src/transport/tests/test_listener_api.rs
@@ -1,5 +1,5 @@
 use crate::{
-    transport::{SipAddr, TcpListenerConnection, WebSocketListenerConnection},
+    transport::{TcpListenerConnection, WebSocketListenerConnection},
     Result,
 };
 
@@ -8,8 +8,7 @@ use crate::{
 async fn test_tcp_listener_connection_api() -> Result<()> {
     // Create TCP listener connection with a specific port to avoid conflicts
     let socket_addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;
-    let local_addr = SipAddr::new(crate::sip::transport::Transport::Tcp, socket_addr.into());
-    let tcp_listener = TcpListenerConnection::new(local_addr, None).await?;
+    let tcp_listener = TcpListenerConnection::new(socket_addr, None).await?;
 
     // Get the address (should be the same as input since we don't bind in new())
     let bound_addr = tcp_listener.get_addr().clone();
@@ -35,8 +34,7 @@ async fn test_tcp_listener_connection_api() -> Result<()> {
 async fn test_websocket_listener_connection_api() -> Result<()> {
     // Create WebSocket listener connection
     let socket_addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;
-    let local_addr = SipAddr::new(crate::sip::transport::Transport::Ws, socket_addr.into());
-    let ws_listener = WebSocketListenerConnection::new(local_addr, None, false).await?;
+    let ws_listener = WebSocketListenerConnection::new(socket_addr, None, false).await?;
 
     // Get the address (should be the same as input since we don't bind in new())
     let bound_addr = ws_listener.get_addr().clone();
@@ -52,6 +50,12 @@ async fn test_websocket_listener_connection_api() -> Result<()> {
         Some(crate::sip::transport::Transport::Ws)
     );
     assert_eq!(bound_addr.addr.host.to_string(), "127.0.0.1");
+
+    let wss_listener = WebSocketListenerConnection::new(socket_addr, None, true).await?;
+    assert_eq!(
+        wss_listener.get_addr().r#type,
+        Some(crate::sip::transport::Transport::Wss)
+    );
 
     Ok(())
 }

--- a/src/transport/tests/test_tls_reload.rs
+++ b/src/transport/tests/test_tls_reload.rs
@@ -152,12 +152,11 @@ async fn test_reload_error_handling_invalid_key() -> Result<()> {
 #[cfg(feature = "rustls")]
 #[tokio::test]
 async fn test_tls_listener_connection_with_config() -> Result<()> {
-    use crate::transport::{SipAddr, TlsConfig, TlsListenerConnection};
+    use crate::transport::{TlsConfig, TlsListenerConnection};
     use std::net::SocketAddr;
 
     let (cert, key) = generate_test_cert("test.example.com")?;
     let socket_addr: SocketAddr = "127.0.0.1:0".parse()?;
-    let local_addr = SipAddr::new(crate::sip::transport::Transport::Tls, socket_addr.into());
 
     let config = TlsConfig {
         cert: Some(cert.into_bytes()),
@@ -165,7 +164,11 @@ async fn test_tls_listener_connection_with_config() -> Result<()> {
         ..Default::default()
     };
 
-    let _tls_listener = TlsListenerConnection::new(local_addr, None, config).await?;
+    let tls_listener = TlsListenerConnection::new(socket_addr, None, config).await?;
+    assert_eq!(
+        tls_listener.get_addr().r#type,
+        Some(crate::sip::transport::Transport::Tls)
+    );
 
     Ok(())
 }

--- a/src/transport/tls.rs
+++ b/src/transport/tls.rs
@@ -273,12 +273,15 @@ pub struct TlsListenerConnection {
 
 impl TlsListenerConnection {
     pub async fn new(
-        local_addr: SipAddr,
+        local_addr: SocketAddr,
         external: Option<SocketAddr>,
         config: TlsConfig,
     ) -> Result<Self> {
         let inner = TlsListenerConnectionInner {
-            local_addr,
+            local_addr: SipAddr {
+                r#type: Some(crate::sip::transport::Transport::Tls),
+                addr: local_addr.into(),
+            },
             external: external.map(|addr| SipAddr {
                 r#type: Some(crate::sip::transport::Transport::Tls),
                 addr: addr.into(),

--- a/src/transport/websocket.rs
+++ b/src/transport/websocket.rs
@@ -47,7 +47,7 @@ pub struct WebSocketListenerConnection {
 
 impl WebSocketListenerConnection {
     pub async fn new(
-        local_addr: SipAddr,
+        local_addr: SocketAddr,
         external: Option<SocketAddr>,
         is_secure: bool,
     ) -> Result<Self> {
@@ -58,7 +58,10 @@ impl WebSocketListenerConnection {
         };
 
         let inner = WebSocketListenerConnectionInner {
-            local_addr,
+            local_addr: SipAddr {
+                r#type: Some(transport_type),
+                addr: local_addr.into(),
+            },
             external: external.map(|addr| SipAddr {
                 r#type: Some(transport_type),
                 addr: addr.into(),


### PR DESCRIPTION
This PR changes the `new` methods on `TcpListenerConnection`, `TlsListenerConnection`, and `WebSocketListenerConnection` so they tag their `local_addr` `SipAddr` with the correct `Transport` type e.g. `TlsListenerConnection` uses `Transport::Tls`.  This makes it so those listeners generate the correct `Contact:` headers instead of, e.g. a `TlsListenerConnection`'s `local_addr` causing a plain `sip:...@192.168.1.10:<udp_port>;transport=udp` `Contact:` header to be generated.

Previously, for everything but `UdpConnection`, `local_addr` was set to a `SipAddr` which the user passed in, but this didn't make sense because `SipAddr` is just a `SocketAddr` + a `Transport` type.  It wouldn't make sense to pass in a `Transport` type at odds with the type of listener being constructed, so callers of the `new` method always just passed in `None` for the transport and that's how it stayed causing the `Contact:` header builder to fall back to the `default_contact_uri` which generated an invalid `Contact:` header if the default listener didn't match the type of connection being handled.  Since it never makes sense to pass in a `SipAddr` with a transport different from the transport used by `<whatever>ListenerConnection`, I made all the constructors do what `UdpConnection::create_connection` does and just accept a `SocketAddr`, which is the only data the constructor really needs to know.  Inside the constructor, `local_addr` is constructed by wrapping the `SocketAddr` in a `SipAddr` with the correct `Transport`.