### PR TITLE
feat: allow overriding the address advertised in Record-Route

### DIFF
--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -394,7 +394,7 @@ async fn handle_invite(state: AppState, mut tx: Transaction) -> Result<()> {
         .unwrap_or_default();
     let target = state.inner.users.lock().await.get(&callee).cloned();
 
-    let record_route = tx.endpoint_inner.get_record_route(None)?;
+    let record_route = tx.endpoint_inner.get_record_route()?;
 
     let target = match target {
         Some(u) => u,

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -394,7 +394,7 @@ async fn handle_invite(state: AppState, mut tx: Transaction) -> Result<()> {
         .unwrap_or_default();
     let target = state.inner.users.lock().await.get(&callee).cloned();
 
-    let record_route = tx.endpoint_inner.get_record_route()?;
+    let record_route = tx.endpoint_inner.get_record_route(None)?;
 
     let target = match target {
         Some(u) => u,

--- a/src/transaction/endpoint.rs
+++ b/src/transaction/endpoint.rs
@@ -521,28 +521,26 @@ impl EndpointInner {
         self.transport_layer.get_addrs()
     }
 
-    /// `addr` overrides which local address is advertised, without it the endpoint's
-    /// first listener is used.
-    pub fn get_record_route(
-        &self,
-        addr: Option<SipAddr>,
-    ) -> Result<crate::sip::typed::RecordRoute> {
-        let first_addr = match addr {
-            Some(addr) => addr,
-            None => self
-                .transport_layer
-                .get_addrs()
-                .first()
-                .ok_or(Error::EndpointError("not sipaddrs".to_string()))
-                .cloned()?,
-        };
-        let mut uri: crate::sip::Uri = first_addr.into();
+    pub fn get_record_route(&self) -> Result<crate::sip::typed::RecordRoute> {
+        let first_addr = self
+            .transport_layer
+            .get_addrs()
+            .first()
+            .ok_or(Error::EndpointError("not sipaddrs".to_string()))
+            .cloned()?;
+        Ok(self.get_record_route_with_addr(first_addr))
+    }
+
+    /// Record-Route advertising `addr` instead of the endpoint's first listener, for an
+    /// endpoint with several listeners where the one a peer must use is not the first.
+    pub fn get_record_route_with_addr(&self, addr: SipAddr) -> crate::sip::typed::RecordRoute {
+        let mut uri: crate::sip::Uri = addr.into();
         uri.params.push(crate::sip::Param::Lr);
-        Ok(crate::sip::typed::RecordRoute {
+        crate::sip::typed::RecordRoute {
             display_name: None,
             uri,
             params: vec![],
-        })
+        }
     }
 
     pub fn get_via(

--- a/src/transaction/endpoint.rs
+++ b/src/transaction/endpoint.rs
@@ -521,13 +521,21 @@ impl EndpointInner {
         self.transport_layer.get_addrs()
     }
 
-    pub fn get_record_route(&self) -> Result<crate::sip::typed::RecordRoute> {
-        let first_addr = self
-            .transport_layer
-            .get_addrs()
-            .first()
-            .ok_or(Error::EndpointError("not sipaddrs".to_string()))
-            .cloned()?;
+    /// `addr` overrides which local address is advertised, without it the endpoint's
+    /// first listener is used.
+    pub fn get_record_route(
+        &self,
+        addr: Option<SipAddr>,
+    ) -> Result<crate::sip::typed::RecordRoute> {
+        let first_addr = match addr {
+            Some(addr) => addr,
+            None => self
+                .transport_layer
+                .get_addrs()
+                .first()
+                .ok_or(Error::EndpointError("not sipaddrs".to_string()))
+                .cloned()?,
+        };
         let mut uri: crate::sip::Uri = first_addr.into();
         uri.params.push(crate::sip::Param::Lr);
         Ok(crate::sip::typed::RecordRoute {

--- a/src/transaction/tests/test_endpoint.rs
+++ b/src/transaction/tests/test_endpoint.rs
@@ -119,10 +119,7 @@ async fn test_get_record_route_addr_override() {
         .await
         .expect("create_test_endpoint");
 
-    let default_rr = endpoint
-        .inner
-        .get_record_route(None)
-        .expect("get_record_route(None)");
+    let default_rr = endpoint.inner.get_record_route().expect("get_record_route");
     assert_eq!(default_rr.uri.to_string(), "sip:127.0.0.1:15060;lr");
 
     let override_addr = crate::transport::SipAddr {
@@ -134,9 +131,6 @@ async fn test_get_record_route_addr_override() {
             port: Some(15061.into()),
         },
     };
-    let override_rr = endpoint
-        .inner
-        .get_record_route(Some(override_addr))
-        .expect("get_record_route(Some)");
+    let override_rr = endpoint.inner.get_record_route_with_addr(override_addr);
     assert_eq!(override_rr.uri.to_string(), "sip:127.0.0.1:15061;lr");
 }

--- a/src/transaction/tests/test_endpoint.rs
+++ b/src/transaction/tests/test_endpoint.rs
@@ -112,3 +112,31 @@ async fn test_endpoint_recvrequests() {
         }
     }
 }
+
+#[tokio::test]
+async fn test_get_record_route_addr_override() {
+    let endpoint = super::create_test_endpoint(Some("127.0.0.1:15060"))
+        .await
+        .expect("create_test_endpoint");
+
+    let default_rr = endpoint
+        .inner
+        .get_record_route(None)
+        .expect("get_record_route(None)");
+    assert_eq!(default_rr.uri.to_string(), "sip:127.0.0.1:15060;lr");
+
+    let override_addr = crate::transport::SipAddr {
+        r#type: Some(crate::sip::Transport::Udp),
+        addr: crate::sip::HostWithPort {
+            host: crate::sip::Host::IpAddr(std::net::IpAddr::V4(std::net::Ipv4Addr::new(
+                127, 0, 0, 1,
+            ))),
+            port: Some(15061.into()),
+        },
+    };
+    let override_rr = endpoint
+        .inner
+        .get_record_route(Some(override_addr))
+        .expect("get_record_route(Some)");
+    assert_eq!(override_rr.uri.to_string(), "sip:127.0.0.1:15061;lr");
+}


### PR DESCRIPTION


 `get_record_route` always builds the URI from the first entry of `transport_layer.get_addrs()` and a proxy can't advertise anything other than its primary listener. It also can't patch it afterwards either as the `RecordRoute` is built and returned in one call

## why is this a problem?

- a P-CSCF terminating IPSec listens on an unprotected port _and_ a protected port
- Record-Route has to advertise the **protected one**, or in-dialog requests come back to the
  unprotected port and arrive outside the security association, leaking data that should be encrypted

## summary of changes

- `get_record_route_with_addr ` takes an `Option<SipAddr>`
- test in `test_endpoint.rs` covers both paths; build, test and fmt pass

Thanks for your time! 